### PR TITLE
Add RRIDs to databases

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -446,28 +446,28 @@ We extracted nodes from standard terminologies, which provide curated vocabulari
 The ease of mapping external vocabularies, adoption, and comprehensiveness were primary selection criteria.
 Hetionet v1.0 includes nodes from 5 ontologies — which provide hierarchy of entities for a specific domain — selected for their conformity to current best practices [@doi:10.1371/journal.pcbi.1004743].
 
-We selected 137 terms from the [Disease Ontology](http://disease-ontology.org/) [@doi:10.1093/nar/gkr972; @doi:10.1093/nar/gku1011] (which we refer to as DO Slim [@doi:10.15363/thinklab.d44; @doi:10.5281/zenodo.45584]) as our **disease** set.
+We selected 137 terms from the [Disease Ontology](http://disease-ontology.org/) (RRID:SCR_000476) [@doi:10.1093/nar/gkr972; @doi:10.1093/nar/gku1011] (which we refer to as DO Slim [@doi:10.15363/thinklab.d44; @doi:10.5281/zenodo.45584]) as our **disease** set.
 Our goal was to identify complex diseases that are distinct and specific enough to be clinically relevant yet general enough to be well annotated.
 To this end, we included diseases that have been studied by GWAS and cancer types from `TopNodes_DOcancerslim` [@doi:10.1093/database/bav032].
 We ensured that no DO Slim disease was a subtype of another DO Slim disease.
-**Symptoms** were extracted from [MeSH](http://www.ncbi.nlm.nih.gov/mesh) by taking the 438 descendants of _Signs and Symptoms_ [@doi:10.15363/thinklab.d67; @doi:10.5281/zenodo.45586].
+**Symptoms** were extracted from [MeSH](http://www.ncbi.nlm.nih.gov/mesh) (RRID:SCR_004750) by taking the 438 descendants of _Signs and Symptoms_ [@doi:10.15363/thinklab.d67; @doi:10.5281/zenodo.45586].
 
-Approved small molecule **compounds** with documented chemical structures were extracted from [DrugBank](http://www.drugbank.ca/) version 4.2 [@doi:10.1093/nar/gkt1068; @doi:10.15363/thinklab.d40; @doi:10.5281/zenodo.45579].
+Approved small molecule **compounds** with documented chemical structures were extracted from [DrugBank](http://www.drugbank.ca/) (RRID:SCR_002700) version 4.2 [@doi:10.1093/nar/gkt1068; @doi:10.15363/thinklab.d40; @doi:10.5281/zenodo.45579].
 Unapproved compounds were excluded because our focus was repurposing.
 In addition, unapproved compounds tend to be less studied than approved compounds making them less attractive for our approach where robust network connectivity is critical.
 Finally, restricting to small molecules with known documented structures enabled us to map between compound vocabularies (see [Mappings](#mappings)).
 
-**Side effects** were extracted from [SIDER](http://sideeffects.embl.de/) version 4.1 [@doi:10.1093/nar/gkv1075; @doi:10.15363/thinklab.d97; @doi:10.5281/zenodo.45521].
-SIDER codes side effects using [UMLS](https://www.nlm.nih.gov/research/umls/) identifiers [@doi:10.1093/nar/gkh061], which we also adopted.
+**Side effects** were extracted from [SIDER](http://sideeffects.embl.de/) (RRID:SCR_004321) version 4.1 [@doi:10.1093/nar/gkv1075; @doi:10.15363/thinklab.d97; @doi:10.5281/zenodo.45521].
+SIDER codes side effects using [UMLS](https://www.nlm.nih.gov/research/umls/) (RRID:SCR_006363) identifiers [@doi:10.1093/nar/gkh061], which we also adopted.
 **Pharmacologic Classes** were extracted from the DrugCentral [data repository](https://github.com/olegursu/drugtarget "DrugCentral data: olegursu/drugtarget on GitHub") [@doi:10.1093/nar/gkw993; @doi:10.15363/thinklab.d186].
 Only pharmacologic classes corresponding to the "Chemical/Ingredient", "Mechanism of Action", and "Physiologic Effect" [FDA class types](https://purl.access.gpo.gov/GPO/LPS118712) were included to avoid pharmacologic classes that were synonymous with indications [@doi:10.15363/thinklab.d186].
 
-Protein-coding human **genes** were extracted from [Entrez Gene](http://www.ncbi.nlm.nih.gov/gene) [@doi:10.1093/nar/gkq1237; @doi:10.15363/thinklab.d34; @doi:10.5281/zenodo.45524].
-Anatomical structures, which we refer to as **anatomies**, were extracted from [Uberon](http://uberon.org) [@doi:10.1186/gb-2012-13-1-r5].
+Protein-coding human **genes** were extracted from [Entrez Gene](http://www.ncbi.nlm.nih.gov/gene) (RRID:SCR_002473) [@doi:10.1093/nar/gkq1237; @doi:10.15363/thinklab.d34; @doi:10.5281/zenodo.45524].
+Anatomical structures, which we refer to as **anatomies**, were extracted from [Uberon](http://uberon.org) (RRID:SCR_010668) [@doi:10.1186/gb-2012-13-1-r5].
 We selected a subset of 402 Uberon terms by excluding terms known not to exist in humans and terms that were overly broad or arcane [@doi:10.15363/thinklab.d41; @doi:10.5281/zenodo.45527].
 
-**Pathways** were extracted by combining human pathways from [WikiPathways](http://www.wikipathways.org/) [@doi:10.1093/nar/gkv1024; @doi:10.1371/journal.pbio.0060184], [Reactome](http://www.reactome.org/) [@doi:10.1093/nar/gkv1351], and the [Pathway Interaction Database](http://pid.nci.nih.gov/) [@doi:10.1093/nar/gkn653].
-The latter two resources were retrieved from [Pathway Commons](http://www.pathwaycommons.org/pc2/) [@doi:10.1093/nar/gkq1039], which compiles pathways from several providers.
+**Pathways** were extracted by combining human pathways from [WikiPathways](http://www.wikipathways.org/) (RRID:SCR_002134) [@doi:10.1093/nar/gkv1024; @doi:10.1371/journal.pbio.0060184], [Reactome](http://www.reactome.org/) (RRID:SCR_003485) [@doi:10.1093/nar/gkv1351], and the [Pathway Interaction Database](http://pid.nci.nih.gov/) (RRID:SCR_006866) [@doi:10.1093/nar/gkn653].
+The latter two resources were retrieved from [Pathway Commons](http://www.pathwaycommons.org/pc2/) (RRID:SCR_002103) [@doi:10.1093/nar/gkq1039], which compiles pathways from several providers.
 Duplicate pathways and pathways without multiple participating genes were removed [@doi:10.15363/thinklab.d72; @doi:10.5281/zenodo.48810].
 **Biological processes**, **cellular components**, and **molecular functions** were extracted from the [Gene Ontology](http://geneontology.org/) [@doi:10.1038/75556].
 Only terms with 2–1000 annotated genes were included.
@@ -487,11 +487,11 @@ UniChem's [@doi:10.1186/1758-2946-5-3] Connectivity Search [@doi:10.1186/s13321-
 
 ### Edges
 
-_Anatomy–downregulates–Gene_ and _Anatomy–upregulates–Gene_ edges [@doi:10.5281/zenodo.47157; @doi:10.15363/thinklab.d124; @doi:10.15363/thinklab.d81] were extracted from  [Bgee](http://bgee.org/) [@doi:10.1007/978-3-540-69828-9_12], which computes differentially expressed genes by anatomy in post-juvenile adult humans.
+_Anatomy–downregulates–Gene_ and _Anatomy–upregulates–Gene_ edges [@doi:10.5281/zenodo.47157; @doi:10.15363/thinklab.d124; @doi:10.15363/thinklab.d81] were extracted from  [Bgee](http://bgee.org/) (RRID:SCR_002028) [@doi:10.1007/978-3-540-69828-9_12], which computes differentially expressed genes by anatomy in post-juvenile adult humans.
 _Anatomy–expresses–Gene_ edges were extracted from Bgee and [TISSUES](http://tissues.jensenlab.org/) [@doi:10.7717/peerj.1054; @doi:10.5281/zenodo.27244; @doi:10.15363/thinklab.d91].
 
 _Compound–binds–Gene_ edges were aggregated from [BindingDB](https://bindingdb.org) [@doi:10.2174/1386207013330670; @doi:10.1093/nar/gkv1072], [DrugBank](http://www.drugbank.ca/) [@doi:10.1093/nar/gkj067; @doi:10.1093/nar/gkt1068], and [DrugCentral](http://drugcentral.org/) [@doi:10.1093/nar/gkw993].
-Only binding relationships to single proteins with affinities of at least 1 μM (as determined by Kd, Kᵢ, or IC₅₀) were selected from the October 2015 release of BindingDB [@doi:10.15363/thinklab.d53; @doi:10.5281/zenodo.33987].
+Only binding relationships to single proteins with affinities of at least 1 μM (as determined by Kd, Kᵢ, or IC₅₀) were selected from the October 2015 release of BindingDB (RRID:SCR_000390) [@doi:10.15363/thinklab.d53; @doi:10.5281/zenodo.33987].
 Target, carrier, transporter, and enzyme interactions with single proteins (i.e. excluding protein groups) were extracted from DrugBank 4.2 [@doi:10.15363/thinklab.d65; @doi:10.5281/zenodo.45579].
 In addition, all mapping DrugCentral target relationships were included [@doi:10.15363/thinklab.d186].
 
@@ -502,18 +502,18 @@ _Pharmacologic Class–includes–Compound_ edges were extracted from DrugCentra
 _Compound–downregulates–Gene_ and _Compound–upregulates–Gene_ relationships were computed from LINCS L1000 as described in [Intermediate resources](#intermediate-resources).
 
 _Disease–associates–Gene_ edges were extracted from the GWAS Catalog [@doi:10.5281/zenodo.48428], DISEASES [@doi:10.15363/thinklab.d106; @doi:10.5281/zenodo.48425], DisGeNET [@doi:10.15363/thinklab.d105; @doi:10.5281/zenodo.48426], and DOAF [@doi:10.15363/thinklab.d94; @doi:10.5281/zenodo.48427].
-The [GWAS Catalog](https://www.ebi.ac.uk/gwas/) compiles disease–SNP associations from published GWAS [@doi:10.1093/nar/gkw1133].
+The [GWAS Catalog](https://www.ebi.ac.uk/gwas/) (RRID:SCR_012745) compiles disease–SNP associations from published GWAS [@doi:10.1093/nar/gkw1133].
 We aggregated overlapping loci associated with each disease and identified the mode reported gene for each high confidence locus [@doi:10.15363/thinklab.d80; @doi:10.15363/thinklab.d71].
 [DISEASES](http://diseases.jensenlab.org/Search) integrates evidence of association from text mining, curated catalogs, and experimental data [@doi:10.1016/j.ymeth.2014.11.020].
 Associations from DISEASES with integrated scores ≥ 2 were included after removing the contribution of DistiLD.
-[DisGeNET](http://www.disgenet.org) integrates evidence from over 10 sources and reports a single score for each association [@doi:10.1093/database/bav028; @doi:10.1093/nar/gkw943].
+[DisGeNET](http://www.disgenet.org) (RRID:SCR_006178) integrates evidence from over 10 sources and reports a single score for each association [@doi:10.1093/database/bav028; @doi:10.1093/nar/gkw943].
 Associations with scores ≥ 0.06 were included.
 DOAF mines Entrez Gene GeneRIFs (textual annotations of gene function) for disease mentions [@doi:10.1371/journal.pone.0049686].
 Associations with 3 or more supporting GeneRIFs were included.
 _Disease–downregulates–Gene_ and _Disease–upregulates–Gene_ relationships [@doi:10.15363/thinklab.d96; @doi:10.5281/zenodo.46866] were computed using [STARGEO](http://stargeo.org/) as described in [Intermediate resources](#intermediate-resources).
 
 _Disease–localizes–Anatomy_, _Disease–presents–Symptom_, and _Disease–resembles–Disease_ edges were calculated from MEDLINE co-occurrence [@doi:10.15363/thinklab.d67; @doi:10.5281/zenodo.48445].
-MEDLINE is a subset of 21 million PubMed articles for which designated human curators have assigned topics.
+MEDLINE (RRID:SCR_002185) is a subset of 21 million PubMed articles for which designated human curators have assigned topics.
 When retrieving articles for a given topic (MeSH term), we activated two non-default search options as specified below: `majr` for selecting only articles where the topic is major and `noexp` for suppressing explosion (returning articles linked to MeSH subterms).
 We identified 4,161,769 articles with two or more disease topics; 696,252 articles with both a disease topic (`majr`) and an anatomy topic (`noexp`) [@doi:10.15363/thinklab.d93]; and 363,928 articles with both a disease topic (`majr`) and a symptom topic (`noexp`).
 We used a Fisher's exact test [@doi:10.2307/2340521] to identify pairs of terms that occurred together more than would be expected by chance in their respective corpus.


### PR DESCRIPTION
The eLife editorial team commented on our submission:

> To help promote the identification, discovery, and reuse of key research resources, we encourage you to include Research Resource Identifiers (RRIDs) within the Materials and Methods section to identify model organisms, cells lines, antibodies, and tools (such as software or databases) you have used (e.g. RRID:AB_2178887 for an antibody, RRID:MGI:3840442 for an organism, RRID:CVCL_1H60 for a cell line, and RRID:SCR_007358 for a tool). The RRID Portal (https://scicrunch.org/resources) lists existing RRIDs, and instructions for creating a new one if an RRID matching the resource does not already exist.

In addition, eLife has two blog posts on RRIDs:

+ [eLife joins the Resource Identification Initiative](https://elifesciences.org/inside-elife/f416c326/elife-joins-the-resource-identification-initiative)
+ [RRIDs: How did we get here and where are we going?](https://elifesciences.org/inside-elife/ff683ecc/rrids-how-did-we-get-here-and-where-are-we-going)

This PR adds RRID mentions to the manuscript. For many resources, I was unable to find RRIDs. Most notably perhaps was the Gene Ontology, although the problem could have also been that the [search feature](https://scicrunch.org/resources/Tools/search?q=%22Gene%20Ontology%22&l=%22Gene%20Ontology%22) is not got.